### PR TITLE
download correct `yt-dlp` release artifact

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -2,47 +2,21 @@ import { opt } from "./options";
 
 const { core, console, http, file, utils } = iina;
 
-const YTDLP_URL = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos.zip";
+const YTDLP_URL = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos";
 
 export async function downloadYTDLP() {
-  const tempID = new Date().getTime();
-  const downloadedZip = utils.resolvePath(`@data/yt-dlp_${tempID}.zip`);
-  const unzipFolder = utils.resolvePath(`@data/yt-dlp_${tempID}`);
-  const destFolder = utils.resolvePath(`@data/yt-dlp`);
+  const downloadFile = utils.resolvePath(`@data/yt-dlp`);
   let errorMessage = null;
   try {
-    console.log(`Downloading yt-dlp to ${downloadedZip}`);
-    await http.download(YTDLP_URL, downloadedZip);
-    const res = await utils.exec("/bin/bash", [
-      "-c",
-      `
-      TARGET="${destFolder}";
-      rm -rf "${destFolder}_*";
-      if [ -e "$TARGET" ] && [ ! -d "$TARGET" ] && [ -f "$TARGET" ]; then
-        rm -rf "$TARGET";
-      fi;
-      if [ ! -e "$TARGET" ]; then
-        mkdir -p "$TARGET";
-      fi;
-      unzip "${downloadedZip}" -d "${unzipFolder}" &&
-      rm -rf "$TARGET"/* &&
-      mv "${unzipFolder}"/* "$TARGET"/ &&
-      rm "${downloadedZip}" &&
-      xattr -cr "$TARGET"
-      `,
-    ]);
-    if (res.status !== 0) {
-      throw new Error(`Failed to unzip yt-dlp: ${res.stderr}`);
-    }
+    console.log(`Downloading yt-dlp at ${downloadFile}`);
+    await http.download(YTDLP_URL, downloadFile);
   } catch (e) {
     console.error(e.toString());
     errorMessage = e.toString();
-  } finally {
     try {
-      if (file.exists(downloadedZip)) file.delete(downloadedZip);
-      if (file.exists(unzipFolder)) file.delete(unzipFolder);
+      if (file.exists(downloadFile)) file.delete(downloadFile);
     } catch (e1) {
-      console.error("Failed to delete temp files: " + e1.toString());
+      console.error("Failed to clean up: " + e1.toString());
     }
   }
   return errorMessage;
@@ -50,7 +24,7 @@ export async function downloadYTDLP() {
 
 export function findBinary(): string {
   let path = "youtube-dl";
-  const searchList = [opt.ytdl_path, "@data/yt-dlp/yt-dlp_macos", "yt-dlp", "youtube-dl"];
+  const searchList = [opt.ytdl_path, "@data/yt-dlp", "yt-dlp"];
   for (const item of searchList) {
     if (utils.fileInPath(item)) {
       console.log(`Found youtube-dl; using ${item}`);


### PR DESCRIPTION
The plugin installs the wrong release artifact.

It should install [yt-dlp_macos](https://github.com/yt-dlp/yt-dlp#:~:text=Universal%20MacOS%20(10.15+)%20standalone%20executable%20(recommended%20for%20MacOS)) - which is a standalone executable of size 34.1 MB. It also supports auto-updates with `yt-dlp -U`. This is the same executable that comes bundled with IINA.

What the plugin currently installs is [yt-dlp_macos.zip](https://github.com/yt-dlp/yt-dlp#:~:text=Unpackaged%20MacOS%20(10.15+)%20executable%20(no%20auto%2Dupdate)) - which is a zipped directory of size, when unzipped, 143.3 MB!