### PR TITLE
update the bundled yt-dlp itself instead of downloading a fresh copy; redesign downloads window

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -4,7 +4,7 @@
   "version": "0.9.8",
   "ghRepo": "iina/plugin-online-media",
   "ghVersion": 10,
-  "description": "Official plugin for playing online media via yt-dlp / youtube-dl. The built-in youtube-dl support will be disabled when this plugin is enabled.",
+  "description": "Official plugin for playing online media via yt-dlp/youtube-dl. The built-in controls will be disabled when this plugin is enabled.",
   "author": {
     "name": "IINA Developers",
     "email": "developers@iina.io",
@@ -12,8 +12,7 @@
   },
   "entry": "dist/index.js",
   "globalEntry": "dist/global.js",
-  "permissions": ["show-osd", "file-system", "network-request"],
-  "allowedDomains": ["github.com"],
+  "permissions": ["show-osd", "file-system"],
   "preferencesPage": "pref.html",
   "preferenceDefaults": {
     "ytdl_path": "",

--- a/Info.json
+++ b/Info.json
@@ -4,7 +4,7 @@
   "version": "0.9.8",
   "ghRepo": "iina/plugin-online-media",
   "ghVersion": 10,
-  "description": "Official plugin for playing online media via yt-dlp/youtube-dl. The built-in controls will be disabled when this plugin is enabled.",
+  "description": "Official plugin for playing online media via yt-dlp.",
   "author": {
     "name": "IINA Developers",
     "email": "developers@iina.io",

--- a/downloads.html
+++ b/downloads.html
@@ -72,10 +72,6 @@
             margin-bottom: 6px;
         }
 
-        #download-error {
-            color: #ff3b30;
-        }
-
         @media (prefers-color-scheme: dark) {
             body {
                 color: #eee;
@@ -191,7 +187,6 @@
                         <div></div>
                     </div>
                 </div>
-                <div id="download-error"></div>
                 <div id="download-info"></div>
             </div>
         </div>

--- a/downloads.html
+++ b/downloads.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Status and Downloads</title>
+    <title>Online Media</title>
     <style>
         body {
             color-scheme: light dark;
@@ -40,36 +40,34 @@
         }
 
         .no-task {
-            padding: 10px;
+            padding: 5px;
         }
 
         h4 {
-            margin: 0;
-            padding: 8px;
+            padding: 5px;
             background: rgba(200, 200, 200, .6);
         }
 
-        .info-container {
-            padding: 10px 10px 0 10px;
+        button {
+            padding: 5px;
+            margin: 0px 0px 10px 10px;
         }
 
-        .binary-msg,
-        .download-container {
-            padding: 8px 0;
+        pre {
+            margin: 0px;
+            display: inline-block;
+            white-space: pre-wrap;
         }
 
-        .binary-msg {
-            color: rgba(0, 0, 0, .6);
-        }
-
-        #downloading {
+        .spinner-container {
             display: none;
             text-align: center;
             padding: 20px 10px 10px 10px;
         }
 
-        #downloading .message {
-            margin-bottom: 6px;
+        .result-container {
+            padding: 5px;
+            display: none;
         }
 
         @media (prefers-color-scheme: dark) {
@@ -89,10 +87,6 @@
 
             h4 {
                 background: rgba(100, 100, 100, .6);
-            }
-
-            .binary-msg {
-                color: rgba(255, 255, 255, .7);
             }
         }
     </style>
@@ -168,32 +162,24 @@
 </head>
 
 <body>
-    <section id="status">
-        <h4>Status</h4>
-        <div class="info-container">
-            <button id="check-binary">Verify yt-dlp binary</button>
-            <div class="binary-msg" id="binary-desc"></div>
-            <div class="binary-msg" id="binary-version"></div>
-            <button id="download-binary">Download latest yt-dlp</button>
-            <div class="download-container">
-                <div id="downloading">
-                    <div class="message">
-                        Downloading yt-dlp. This may take minutes depending on your connection speed.
-                    </div>
-                    <div class="spinner">
-                        <div></div>
-                        <div></div>
-                        <div></div>
-                        <div></div>
-                    </div>
-                </div>
-                <div id="download-info"></div>
+    <section id="yt-dlp">
+        <h4>Yt-dlp</h4>
+        <button id="verify-binary">Verify Installation</button>
+        <button id="update-binary">Update Now</button>
+        <div id="ytdlp-spinner-container" class="spinner-container">
+            <div id="ytdlp-spinner-message" class="spinner-message"></div>
+            <div class="spinner">
+                <div></div>
+                <div></div>
+                <div></div>
+                <div></div>
             </div>
         </div>
+        <div id="ytdlp-result" class="result-container"></div>
     </section>
     <section id="downloads">
         <h4>Downloads</h4>
-        <div id="content"></div>
+        <div id="download-content" class="result-container"></div>
     </section>
 </body>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iina-plugin-ytdl",
-  "version": "0.9.5",
+  "version": "0.9.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iina-plugin-ytdl",
-      "version": "0.9.5",
+      "version": "0.9.8",
       "license": "ISC",
       "dependencies": {
         "mustache": "^4.2.0"

--- a/pref.html
+++ b/pref.html
@@ -52,11 +52,7 @@
       <input type="text" data-pref-key="ytdl_path" style="width: 100%; margin-top: 2px" />
     </label>
     <p class="small secondary pref-help">
-      Enter the path to the executable. Hint:
-      <br>- You can put just <code>yt-dlp</code> if yt-dlp is already in the $PATH
-      <br>- Uv/pipx-installed yt-dlp is typically located at <code>~/.local/bin/yt-dlp</code>
-      <br>- Homebrew-installed yt-dlp is typically located at <code>/opt/homebrew/bin/yt-dlp</code> for Apple Silicon and
-      <code>/usr/local/bin/yt-dlp</code> for macOS Intel
+      Path to the executable. If in $PATH, just its name.
     </p>
   </div>
   <div class="pref-section">
@@ -104,18 +100,16 @@
       Try yt-dlp first
     </label>
     <p class="small secondary pref-help">
-      Try parsing the URL with yt-dpl first, if it fails, then with IINA's engine - mpv.
-      Instead of the default, where mpv is tried first.
+      Parse the URL with yt-dlp first, instead of (the default) mpv.
     </p>
   </div>
   <div class="pref-section">
     <label>
       <input type="checkbox" data-type="bool" data-pref-key="use_manifest" />
-      Use manifest URL
+      Use master manifest URL
     </label>
     <p class="small secondary pref-help">
-      Use the master manifest URL for formats like HLS and DASH, if available,
-      allowing for video/audio selection at runtime.
+      Access the master manifest URL, if available, to fetch all available video/audio qualities.
     </p>
   </div>
   <div class="pref-section">
@@ -125,8 +119,7 @@
         spellcheck="false" style="width: 100%; margin-top: 2px" />
     </label>
     <p class="small secondary pref-help">
-      Additional raw options to pass to yt-dlp.
-      <br>For example: <code>--write-auto-sub --sub-langs en</code>
+      Additional options to pass to yt-dlp.
     </p>
   </div>
 </body>

--- a/pref.html
+++ b/pref.html
@@ -47,15 +47,17 @@
 
 <body>
   <div class="pref-section">
-    Use custom youtube-dl/yt-dlp:
-    <p class="small secondary pref-help">
-      Enter the path to the youtube-dl or yt-dlp binary.
-      If you are using Homebrew, the path is usually <code>/opt/homebrew/bin/yt-dlp</code> for Apple Sillion Macs and
-      <code>/usr/local/bin/yt-dlp</code> for Intel Macs.
-    </p>
-    <div style="margin-top: 2px">
+    <label>
+      Custom yt-dlp path:
       <input type="text" data-pref-key="ytdl_path" style="width: 100%; margin-top: 2px" />
-    </div>
+    </label>
+    <p class="small secondary pref-help">
+      Enter the path to the executable. Hint:
+      <br>- You can put just <code>yt-dlp</code> if yt-dlp is already in the $PATH
+      <br>- Uv/pipx-installed yt-dlp is typically located at <code>~/.local/bin/yt-dlp</code>
+      <br>- Homebrew-installed yt-dlp is typically located at <code>/opt/homebrew/bin/yt-dlp</code> for Apple Silicon and
+      <code>/usr/local/bin/yt-dlp</code> for macOS Intel
+    </p>
   </div>
   <div class="pref-section">
     Default video and audio quality:
@@ -67,19 +69,19 @@
       <div>
         <label><input type="radio" name="video_quality" value="use_max" data-pref-key />
           Video not larger than:</label>
-        <input type="number" data-pref-key="max_video_height" style="width: 4em" />
+        <input type="number" data-pref-key="max_video_height" style="width: 4.5em" />
         p
       </div>
       <div>
         <label><input type="radio" name="video_quality" value="custom" data-pref-key />
-          Custom youtube-dl format:</label>
+          Custom yt-dlp format:</label>
         <input type="text" data-pref-key="custom_ytdl_format" />
       </div>
     </div>
   </div>
   <div class="pref-section">
     <label>
-      Excluded URLs:
+      URL blacklist:
       <div style="margin-top: 2px">
         <input type="text" data-pref-key="excluded_urls" style="width: 100%; margin-top: 2px" />
       </div>
@@ -88,22 +90,22 @@
   <div class="pref-section">
     <label>
       <input type="checkbox" data-type="bool" data-pref-key="include_subs" />
-      Include subtitles
+      Include subtitle(s)
     </label>
     <div style="margin-top: 4px;"></div>
     <label style="margin-left: 16px;">
       <input type="checkbox" data-type="bool" data-pref-key="include_auto_subs" />
-      Also include auto-generated subtitles
+      Also include auto-generated subtitle
     </label>
   </div>
   <div class="pref-section">
     <label>
       <input type="checkbox" data-type="bool" data-pref-key="try_ytdl_first" />
-      Try youtube-dl first
+      Try yt-dlp first
     </label>
     <p class="small secondary pref-help">
-      Try parsing the URL with youtube-dl first, instead of the default where
-      it's only after mpv failed to open it.
+      Try parsing the URL with yt-dpl first, if it fails, then with IINA's engine - mpv.
+      Instead of the default, where mpv is tried first.
     </p>
   </div>
   <div class="pref-section">
@@ -123,8 +125,8 @@
         spellcheck="false" style="width: 100%; margin-top: 2px" />
     </label>
     <p class="small secondary pref-help">
-      Additional raw options to pass to youtube-dl/yt-dlp, for example:<br>
-      <code>--write-auto-sub --sub-langs en</code>
+      Additional raw options to pass to yt-dlp.
+      <br>For example: <code>--write-auto-sub --sub-langs en</code>
     </p>
   </div>
 </body>

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -1,62 +1,18 @@
 import { opt } from "./options";
 
-const { core, console, http, file, utils } = iina;
+const { core, console, utils } = iina;
 
-const YTDLP_URL = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos.zip";
-
-export async function downloadYTDLP() {
-  const tempID = new Date().getTime();
-  const downloadedZip = utils.resolvePath(`@data/yt-dlp_${tempID}.zip`);
-  const unzipFolder = utils.resolvePath(`@data/yt-dlp_${tempID}`);
-  const destFolder = utils.resolvePath(`@data/yt-dlp`);
-  let errorMessage = null;
-  try {
-    console.log(`Downloading yt-dlp to ${downloadedZip}`);
-    await http.download(YTDLP_URL, downloadedZip);
-    const res = await utils.exec("/bin/bash", [
-      "-c",
-      `
-      TARGET="${destFolder}";
-      rm -rf "${destFolder}_*";
-      if [ -e "$TARGET" ] && [ ! -d "$TARGET" ] && [ -f "$TARGET" ]; then
-        rm -rf "$TARGET";
-      fi;
-      if [ ! -e "$TARGET" ]; then
-        mkdir -p "$TARGET";
-      fi;
-      unzip "${downloadedZip}" -d "${unzipFolder}" &&
-      rm -rf "$TARGET"/* &&
-      mv "${unzipFolder}"/* "$TARGET"/ &&
-      rm "${downloadedZip}" &&
-      xattr -cr "$TARGET"
-      `,
-    ]);
-    if (res.status !== 0) {
-      throw new Error(`Failed to unzip yt-dlp: ${res.stderr}`);
-    }
-  } catch (e) {
-    console.error(e.toString());
-    errorMessage = e.toString();
-  } finally {
-    try {
-      if (file.exists(downloadedZip)) file.delete(downloadedZip);
-      if (file.exists(unzipFolder)) file.delete(unzipFolder);
-    } catch (e1) {
-      console.error("Failed to delete temp files: " + e1.toString());
-    }
-  }
-  return errorMessage;
+export async function updateBinary() {
+  return await utils.exec("iina-ytdl", ["-U"]);
 }
 
-export function findBinary(): string {
-  let path = "youtube-dl";
-  const searchList = [opt.ytdl_path, "@data/yt-dlp/yt-dlp_macos", "yt-dlp", "youtube-dl"];
+export function findBinary(): string | null {
+  const searchList = [opt.ytdl_path, "iina-ytdl"];
   for (const item of searchList) {
     if (utils.fileInPath(item)) {
-      console.log(`Found youtube-dl; using ${item}`);
-      path = item;
-      break;
+      console.log(`Found binary at ${item}`);
+      return item;
     }
   }
-  return path;
+  return null;
 }

--- a/src/downloads-window.js
+++ b/src/downloads-window.js
@@ -25,20 +25,14 @@ function init() {
   });
 
   iina.onMessage("updatingBinary", () => {
-    document.getElementById("download-error").textContent = "";
     document.getElementById("download-info").textContent = "";
     document.getElementById("downloading").style.display = "block";
   });
 
-  iina.onMessage("binaryUpdated", ({ updated, error }) => {
+  iina.onMessage("binaryUpdated", ({ res }) => {
     document.getElementById("downloading").style.display = "none";
-    if (updated) {
-      document.getElementById("download-info").textContent =
-        "Binary updated successfully. Please allow a few seconds preparing and verifying the new binary.";
-      updateBinaryInfo();
-    } else {
-      document.getElementById("download-error").textContent = `Failed to update binary: ${error}`;
-    }
+    document.getElementById("download-info").innerHTML = res.status === 0 ? res.stdout : res.stderr;
+    document.getElementById("download-info").style.color = res.status === 0 ? "" : "#ff3b30";
   });
 
   window.openFile = function (file) {
@@ -74,15 +68,19 @@ function updateBinaryInfo() {
   iina.onMessage("binaryInfo", ({ path, version, errorMessage }) => {
     let description,
       binaryLocation = "";
-    if (path === "youtube-dl") {
-      description = `You are using the yt-dlp binary bundled with IINA.
-        Since IINA's update frequency is lower than yt-dlp, it can be outdated and you may encounter issues.
-        It is recommended to download the latest version using the button below.`;
-    } else if (path === "@data/yt-dlp/yt-dlp_macos") {
-      description = `You are using the yt-dlp binary managed by this plugin. You can update it using the button below.`;
+    if (path === null) {
+      description = `Unable to find yt-dlp.
+        Troubleshooting:
+        - Reinstall IINA (IINA-bundled yt-dlp is missing)
+        - If you have an existing installation of yt-dlp,
+        either put it on $PATH or set its path in 'Plugins>Online Media>Settings>Use custom youtube-dl/yt-dlp'`;
+    } else if (path === "iina-ytdl") {
+      description = `You are using yt-dlp bundled with IINA.
+        It is recommended to keep it up to date using the button below.`;
     } else {
       binaryLocation = path;
-      description = `It seems that you are using a custom yt-dlp binary. You may need to update it manually.`;
+      description = `You are using yt-dlp configured by by you in plugin settings.
+        You may need to update it manually.`;
       document.getElementById("download-binary").style.display = "none";
     }
     if (errorMessage) {

--- a/src/downloads-window.js
+++ b/src/downloads-window.js
@@ -11,27 +11,30 @@ function init() {
     }, 1000));
   const stopUpdate = () => clearInterval(interval);
 
-  iina.onMessage("update", function (message) {
-    if (message.active) {
+  iina.onMessage("update", (msg) => {
+    if (msg.active) {
       startUpdate();
     } else {
       stopUpdate();
     }
-    message.data.forEach((item) => {
+    msg.data.forEach((item) => {
       item[`is_${item.status}`] = true;
       item.dest_base64 = utf8_to_b64(item.dest);
     });
-    document.getElementById("content").innerHTML = mustache.render(TEMPLATE, message);
+    document.getElementById("content").innerHTML = mustache.render(TEMPLATE, msg);
   });
 
   iina.onMessage("updatingBinary", () => {
+    document.getElementById("binary-desc").textContent = "";
+    document.getElementById("binary-version").textContent = "";
     document.getElementById("download-info").textContent = "";
     document.getElementById("downloading").style.display = "block";
   });
 
   iina.onMessage("binaryUpdated", ({ res }) => {
     document.getElementById("downloading").style.display = "none";
-    document.getElementById("download-info").innerHTML = res.status === 0 ? res.stdout : res.stderr;
+    document.getElementById("download-info").textContent =
+      res.status === 0 ? res.stdout : res.stderr;
     document.getElementById("download-info").style.color = res.status === 0 ? "" : "#ff3b30";
   });
 
@@ -63,36 +66,29 @@ function b64_to_utf8(str) {
 }
 
 function updateBinaryInfo() {
-  document.getElementById("binary-desc").textContent = "Checking for yt-dlp binary...";
+  document.getElementById("download-info").textContent = "";
+  document.getElementById("binary-desc").textContent = "Checking for yt-dlp...";
   iina.postMessage("getBinaryInfo");
   iina.onMessage("binaryInfo", ({ path, version, errorMessage }) => {
-    let description,
-      binaryLocation = "";
+    let desc = "";
     if (path === null) {
-      description = `Unable to find yt-dlp.
+      desc = `Unable to find yt-dlp bundled with IINA.
         Troubleshooting:
-        - Reinstall IINA (IINA-bundled yt-dlp is missing)
-        - If you have an existing installation of yt-dlp,
-        either put it on $PATH or set its path in 'Plugins>Online Media>Settings>Use custom youtube-dl/yt-dlp'`;
+        - Reinstall IINA
+        - If you have an existing installation of yt-dlp, either put it in $PATH
+        or set its path in 'Plugins>Online Media>Settings>Custom yt-dlp path'`;
     } else if (path === "iina-ytdl") {
-      description = `You are using yt-dlp bundled with IINA.
+      desc = `You are using yt-dlp bundled with IINA.
         It is recommended to keep it up to date using the button below.`;
     } else {
-      binaryLocation = path;
-      description = `You are using yt-dlp configured by by you in plugin settings.
+      desc = `You are using a custom yt-dlp installation, configured in the plugin settings.
         You may need to update it manually.`;
       document.getElementById("download-binary").style.display = "none";
     }
-    if (errorMessage) {
-      document.getElementById("binary-version").textContent = errorMessage;
-    } else {
-      let message = "Version: " + version;
-      if (binaryLocation) {
-        message += `<br>binary location: ${binaryLocation}`;
-      }
-      document.getElementById("binary-version").innerHTML = message;
-    }
-    document.getElementById("binary-desc").textContent = description;
+    document.getElementById("binary-desc").textContent = desc;
+
+    const info = `Version: ${version}` + (path && path !== "iina-ytdl" ? `<br>Path: ${path}` : "");
+    document.getElementById("binary-version").innerHTML = errorMessage ? errorMessage : info;
   });
 }
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,4 +1,4 @@
-import { downloadYTDLP, findBinary } from "./binary";
+import { updateBinary, findBinary } from "./binary";
 import { downloadVideo, resetStatusNeedUpdate, statusNeedUpdate, tasks } from "./download";
 
 let { console, global, menu, standaloneWindow, file, utils } = iina;
@@ -88,8 +88,8 @@ function showDownloadsWindow() {
 
 async function updateYTDLP() {
   standaloneWindow.postMessage("updatingBinary", null);
-  let error = await downloadYTDLP();
-  standaloneWindow.postMessage("binaryUpdated", { updated: !error, error });
+  let res = await updateBinary();
+  standaloneWindow.postMessage("binaryUpdated", { res });
 }
 
 async function showDownloadYTDLPWindow() {

--- a/src/global.ts
+++ b/src/global.ts
@@ -54,22 +54,23 @@ function showDownloadsWindow() {
     file.showInFinder(fileName);
   });
 
-  standaloneWindow.onMessage("getBinaryInfo", async () => {
+  standaloneWindow.onMessage("verifyBinary", async () => {
     const ytdl = findBinary();
     console.log("Binary path: " + ytdl);
     const res = await utils.exec(ytdl, ["--version"]);
-    standaloneWindow.postMessage("binaryInfo", {
+    standaloneWindow.postMessage("binaryResult", {
       path: ytdl,
-      version: res.stdout,
-      errorMessage: res.stderr,
+      res: res,
     });
   });
 
   standaloneWindow.onMessage("updateBinary", async () => {
-    if (opt.ytdl_path) return;
-    standaloneWindow.postMessage("updatingBinary", null);
+    if (opt.ytdl_path) {
+      standaloneWindow.postMessage("binaryDisableUpdate", null);
+      return;
+    }
     const res = await updateBinary();
-    standaloneWindow.postMessage("binaryUpdated", { res });
+    standaloneWindow.postMessage("binaryExecuted", { res: res, id: "ytdlp" });
   });
 
   standaloneWindow.open();

--- a/src/ytdl-hook.ts
+++ b/src/ytdl-hook.ts
@@ -100,7 +100,7 @@ export async function runYTDLHook(url: string) {
   args.push("--", url);
 
   try {
-    console.log("Running youtube-dl...");
+    console.log("Running ytdl...");
 
     // find the binary
     const ytdl = findBinary();
@@ -108,20 +108,20 @@ export async function runYTDLHook(url: string) {
     // execute
     const out = await utils.exec(ytdl, args);
     if (out.status !== 0) {
-      core.osd("Failed to run youtube-dl");
-      console.error(`Error running youtube-dl: ${out.stderr}`);
+      core.osd("Failed to run ytdl");
+      console.error(`Error running ytdl: ${out.stderr}`);
       return;
     }
-    console.log("Finished running youtube-dl");
+    console.log("Finished running ytdl");
 
     // parse the result
     try {
       let json = JSON.parse(out.stdout);
-      console.log("Youtube-dl succeeded.");
+      console.log("ytdl succeeded.");
       ytdlSuccess(url, json, option);
     } catch (err) {
       core.osd("Failed to fetch online media information");
-      console.error(`Failed to parse youtube-dl's output: ${err}`);
+      console.error(`Failed to parse ytdl's output: ${err}`);
     }
   } catch (err) {
     core.osd("Unknown error.");


### PR DESCRIPTION
This PR basically supersedes [#8](https://github.com/iina/plugin-online-media/pull/8) but I kept that as an alternative because this one has radical design changes that may take time to get approved, so in the meantime we can get that merged.

Also, this PR waits on [iina#5758](https://github.com/iina/iina/pull/5758).