### PR TITLE
fix video track http_headers

### DIFF
--- a/src/add-video.ts
+++ b/src/add-video.ts
@@ -94,6 +94,7 @@ function processVideo(reqfmts: YTDL.Video[], json?: YTDL.Entity) {
         // according to ytdl, if vcodec is None, it's audio
         mpv.command("audio-add", [edlTrack || track.url, "auto", track.format_note || ""]);
       }
+      setHTTPHeaders(track.http_headers);
     }
   } else if (json.url) {
     const edlTrack = edlTrackJoined(


### PR DESCRIPTION
video track without http_headers will make some url return 403 error (e.g. bilibili)