### PR TITLE
Log binary version

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -148,3 +148,22 @@ export function findJSRuntime(): string | null {
   }
   return null;
 }
+
+export async function logVersion(): Promise<void> {
+  const path = findBinary();
+  try {
+    const res = await utils.exec(path, ["--version"]);
+    if (res.status === 0) {
+      const version = res.stdout;
+      // remove trailing newline
+      const cleanVersion = version.substring(0, version.length - 1);
+      console.log("Version: " + cleanVersion);
+    } else {
+      const errorMessage =
+        "Error when executing the binary: " + (res.stderr ? res.stderr : "No error message");
+      console.log(errorMessage);
+    }
+  } catch (err) {
+    console.warn(err);
+  }
+}

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,7 +1,11 @@
-import { downloadYTDLP, updateYTDLP, downloadDeno, findBinary } from "./binary";
+import { downloadYTDLP, updateYTDLP, downloadDeno, findBinary, logVersion } from "./binary";
 import { downloadVideo, resetStatusNeedUpdate, statusNeedUpdate, tasks } from "./download";
 
 let { console, global, menu, standaloneWindow, file, utils } = iina;
+
+// Initialization
+
+logVersion();
 
 // Menu
 


### PR DESCRIPTION
Fixes #14 

A frequent source of IINA issues is due to trouble accessing streaming sites, especially YouTube. One of the first steps in investigating such problems is to determine if the latest version of yt-dlp is being used. But currently, given an IINA log file, it is not possible to determine the version of yt-dlp being used or whether the yt-dlp binary is being managed by the plugin or not.

We log if the binary is managed in `findBinary`. It will say `Found youtube-dl; using ...`. This adds a new function `logVersion` that additionally calls `--version` on the binary and logs the result to the console on startup.

<img width="1424" height="356" alt="a screenshot of the IINA log showing the logged version" src="https://github.com/user-attachments/assets/e4faf634-ab01-4a1c-85ed-a65b291f5c08" />