### PR TITLE
Add ffmpeg configuration for downloads

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -18,6 +18,7 @@
   "preferenceDefaults": {
     "ytdl_path": "",
     "js_runtime": "",
+    "ffmpeg_path": "",
     "excluded_urls": "",
     "try_ytdl_first": false,
     "use_manifests": false,

--- a/downloads.html
+++ b/downloads.html
@@ -67,6 +67,12 @@
             justify-content: space-between;
         }
 
+        .download-warning {
+            color: #ff9500;
+            font-size: 85%;
+            margin-bottom: 4px;
+        }
+
         .task-options a {
             margin-left: 8px;
         }

--- a/pref.html
+++ b/pref.html
@@ -68,6 +68,18 @@
     </div>
   </div>
   <div class="pref-section">
+    FFmpeg:
+    <p class="small secondary pref-help">
+      Enter the path to the ffmpeg binary. ffmpeg is required for yt-dlp to merge the best separate video and audio
+      streams when downloading.
+      If you are using Homebrew, the path is usually <code>/opt/homebrew/bin/ffmpeg</code> for Apple Silicon Macs and
+      <code>/usr/local/bin/ffmpeg</code> for Intel Macs.
+    </p>
+    <div style="margin-top: 2px">
+      <input type="text" data-pref-key="ffmpeg_path" style="width: 100%; margin-top: 2px" />
+    </div>
+  </div>
+  <div class="pref-section">
     Default video and audio quality:
     <div style="margin-top: 4px; line-height: 24px">
       <div>

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,5 +1,6 @@
 import { findBinary } from "./binary";
 import { updateDownloadsWindow } from "./global";
+import { opt } from "./options";
 import { formatFileSize, formatSeconds } from "./utils";
 
 const { console, global, utils } = iina;
@@ -16,6 +17,7 @@ class DownloadTask {
   status: "pending" | "downloading" | "done" | "error" = "pending";
   res: ReturnType<typeof utils.exec>;
   errorMessage: string | null = null;
+  warningMessage: string | null = null;
   downloadedBytes: number = 0;
   totalBytes: number = 0;
   eta: number | null = null;
@@ -28,6 +30,7 @@ class DownloadTask {
     public ytdl: string,
     public jsRuntime: string,
     public format: string | null,
+    public ffmpegLocation: string | null,
   ) {}
 
   get dest() {
@@ -37,9 +40,14 @@ class DownloadTask {
   private get args() {
     const args: string[] = [];
     args.push("-P", this.destFolder);
-    // args.push("--format", this.format);
+    if (this.format) {
+      args.push("--format", this.format);
+    }
     if (this.jsRuntime) {
       args.push("--js-runtimes", this.jsRuntime);
+    }
+    if (this.ffmpegLocation) {
+      args.push("--ffmpeg-location", this.ffmpegLocation);
     }
     args.push(
       "--progress-template",
@@ -94,6 +102,7 @@ class DownloadTask {
       status: this.status,
       start: this.startTime.toString(),
       error: this.errorMessage,
+      warning: this.warningMessage,
       dl: formatFileSize(this.downloadedBytes),
       total: formatFileSize(this.totalBytes),
       eta: formatSeconds(this.eta),
@@ -101,24 +110,87 @@ class DownloadTask {
   }
 }
 
-export async function downloadVideo(url: string, player: string) {
-  // const hasFFmpeg =
-  //   (await utils.exec("/bin/bash", ["-c", "'which ffmpeg'"])).status === 0;
-  // const format = hasFFmpeg ? "bestvideo+bestaudio/best" : "best";
-  // console.log(`FFmpeg found: ${hasFFmpeg}; using format: ${format}`);
-  const format = null;
+async function findFFmpegLocation(): Promise<string | null> {
+  if (opt.ffmpeg_path) {
+    if (utils.fileInPath(opt.ffmpeg_path)) {
+      const resolvedPath = utils.resolvePath(opt.ffmpeg_path);
+      console.log(`Found ffmpeg from preferences; using ${resolvedPath}`);
+      return resolvedPath;
+    }
+    console.warn(`Configured ffmpeg path was not found: ${opt.ffmpeg_path}`);
+  }
 
+  const which = await utils.exec("/usr/bin/which", ["ffmpeg"]);
+  const whichPath = which.stdout.trim();
+  if (which.status === 0 && whichPath) {
+    console.log(`Found ffmpeg using which; using ${whichPath}`);
+    return whichPath;
+  }
+
+  const candidates = [
+    "/opt/homebrew/bin/ffmpeg",
+    "/usr/local/bin/ffmpeg",
+    "/opt/local/bin/ffmpeg",
+    "/sw/bin/ffmpeg",
+  ];
+  for (const candidate of candidates) {
+    if (utils.fileInPath(candidate)) {
+      console.log(`Found ffmpeg; using ${candidate}`);
+      return candidate;
+    }
+  }
+
+  console.warn("ffmpeg was not found; yt-dlp may be unable to merge best video and audio formats");
+  return null;
+}
+
+function formatNeedsFFmpeg(format: string | null): boolean {
+  return !!format && format.includes("+");
+}
+
+export async function downloadVideo(url: string, player: string) {
   const { path, jsRuntime } = await findBinary();
   const resolvedJsRuntime = jsRuntime ? utils.resolvePath(jsRuntime) : "";
-  const filename = (
-    await utils.exec(path, ["--js-runtimes", jsRuntime, "--get-filename", url])
-  ).stdout.replaceAll("\n", "");
+  const ffmpegLocation = await findFFmpegLocation();
+  let format = opt.format;
+  if (!ffmpegLocation && formatNeedsFFmpeg(format)) {
+    console.warn(`ffmpeg was not found; falling back from ${format} to best`);
+    global.postMessage(
+      player,
+      "downloadWarning",
+      "ffmpeg not found; downloading lower-quality single-file format",
+    );
+    format = "best";
+  }
+  console.log(`Using download format: ${format}`);
+
+  const filenameArgs = ["--format", format];
+  if (resolvedJsRuntime) {
+    filenameArgs.push("--js-runtimes", resolvedJsRuntime);
+  }
+  if (ffmpegLocation) {
+    filenameArgs.push("--ffmpeg-location", ffmpegLocation);
+  }
+  filenameArgs.push("--get-filename", "--", url);
+  const filename = (await utils.exec(path, filenameArgs)).stdout.replaceAll("\n", "");
   console.log(filename);
 
   let destFolder = `~/Downloads`;
-  const args: string[] = [];
 
-  const task = new DownloadTask(player, url, filename, destFolder, path, resolvedJsRuntime, format);
+  const task = new DownloadTask(
+    player,
+    url,
+    filename,
+    destFolder,
+    path,
+    resolvedJsRuntime,
+    format,
+    ffmpegLocation,
+  );
+  if (!ffmpegLocation && formatNeedsFFmpeg(opt.format)) {
+    task.warningMessage =
+      "ffmpeg not found; downloading lower-quality single-file format. Set the ffmpeg path in plugin preferences to enable best video and audio downloads.";
+  }
   tasks.push(task);
   task.start();
 }

--- a/src/downloads-window.js
+++ b/src/downloads-window.js
@@ -194,6 +194,9 @@ const TEMPLATE = `
 {{#data}}
 <div class="download-item">
 <div class="filename">{{filename}}</div>
+{{#warning}}
+<div class="download-warning">{{warning}}</div>
+{{/warning}}
 <div class="progress">
 <div class="left">
 {{#is_pending}}

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,3 +43,7 @@ global.onMessage("downloading", () => {
 global.onMessage("downloaded", () => {
   core.osd("Video downloaded");
 });
+
+global.onMessage("downloadWarning", (message) => {
+  core.osd(message.toString());
+});

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,9 @@ export const opt = {
   get js_runtime(): string {
     return preferences.get("js_runtime");
   },
+  get ffmpeg_path(): string {
+    return preferences.get("ffmpeg_path");
+  },
   get try_ytdl_first(): boolean {
     return preferences.get("try_ytdl_first");
   },


### PR DESCRIPTION
Fixes #16

Downloads now use the configured yt-dlp format instead of falling back to yt-dlp defaults. Adds an ffmpeg path preference and discovery fallback so `bestvideo+bestaudio` downloads can be merged.

If ffmpeg is unavailable, downloads fall back to the best single-file format and show a warning in both the player OSD and downloads manager.
<img width="438" height="496" alt="file-fa84b891987b03951308d25b45aeebda" src="https://github.com/user-attachments/assets/57ddcbee-ae35-4494-8417-265fa8d5c243" />
